### PR TITLE
Make colors relative

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -23,6 +23,15 @@
 }
 
 :root {
+  /** There features 
+  These are values that determine the overall look of the theme.
+  - Saturation controls how much of accent color will be mixed into text, background, and surface colors.
+  - Contrast controls how contrast the text colors will be.
+  */
+  --theme-hue: 255;
+  --theme-saturation: 0.2; /* 0...1 where 0 means grayscale colors; 1 means fully saturated colors */
+  --theme-contrast: 0.8; /* 0...1 where 0 means low contrast; 1 means high contrast, black-n-white in fact */
+
   /* Fonts */
   --font-text: "Inter Variable", Arial, sans-serif;
   --font-mono: "JetBrains Mono", "Courier New", Courier, monospace;
@@ -78,10 +87,10 @@
   --color-text-secondary: #757a7f;
   --color-text-tertiary: #a7acb2;
   --color-accent: #0081ff;
+  --color-accent-hover: #0088f0d9;
   --color-accent-b: #0081ff29;
+  --color-accent-b-hover: #0088f033;
   --color-on-accent: white;
-  --color-button-primary-bg-hover: #0088f0d9;
-  --color-button-secondary-bg-hover: #0088f033;
   --color-border-level-2: #99a3ae29;
   --color-border-level-3: #99a3ae52;
   --color-background-blur: #ffffffe6;
@@ -92,21 +101,48 @@
 }
 
 .theme-light {
-  --color-background: white;
-  --color-surface: #99a3ae14;
-  --color-text-primary: #363e48;
-  --color-text-secondary: #757a7f;
-  --color-text-tertiary: #a7acb2;
-  --color-accent: #0081ff;
-  --color-accent-b: #0081ff29;
+  /** Base color
+  By default it's blue ≈ #0289ff
+  Usually it's your brand color. Simply provide your value and the whole theme will be recalculated automatically.
+  Default value is in OKLCH because it produces richer P3 colors, however you can use any color format. 
+  */
+  /* --color-accent: #00bc81; */
+  --color-accent: oklch(0.64 0.21 var(--theme-hue));
+
+  /* Relative colors 
+  These colors are calculated based on the accent color and saturation/contrast values.
+  Feel free to provide exact values if you want to override them.
+  */
+  --color-background-l: calc(0.7 + 0.3 * var(--theme-contrast));
+  --color-background: oklch(
+    from var(--color-accent) var(--color-background-l)
+      calc((1 - var(--color-background-l)) * 0.6 * var(--theme-saturation)) h
+  );
+  --color-background-blur: oklch(from var(--color-background) l c h / 0.8);
+
+  --color-text-primary-l: calc(0.4 - 0.4 * pow(var(--theme-contrast), 10));
+  --color-text-primary: oklch(
+    from var(--color-accent) var(--color-text-primary-l)
+      calc(var(--color-text-primary-l) * 0.3 * var(--theme-saturation)) h
+  );
+
+  --color-text-secondary: oklch(from var(--color-text-primary) l c h / 0.7);
+  --color-text-tertiary: oklch(from var(--color-text-primary) l c h / 0.42);
+  --color-accent-hover: oklch(from var(--color-accent) calc(l - 0.05) c h);
+  --color-accent-b: oklch(from var(--color-accent) l c h / 0.16);
+  --color-accent-b-hover: oklch(from var(--color-accent-b) calc(l - 0.1) c h);
+
+  --color-surface: oklch(from var(--color-text-primary) l c h / 0.04);
   --color-on-accent: white;
-  --color-button-primary-bg-hover: #0088f0d9;
-  --color-button-secondary-bg-hover: #0088f033;
-  --color-border-level-2: #99a3ae29;
-  --color-border-level-3: #99a3ae52;
-  --color-background-blur: #ffffffe6;
-  --color-gradient-bg-start: #0081ff14;
-  --color-gradient-bg-end: #0081ff00;
+  --color-border-level-2: oklch(from var(--color-text-primary) l c h / 0.08);
+  --color-border-level-3: oklch(from var(--color-text-primary) l c h / 0.16);
+
+  --color-gradient-bg-start: oklch(
+    from var(--color-accent) l calc(0.3 * pow(var(--theme-saturation), 0.5)) h /
+      calc(0.5 - 0.5 * pow(var(--theme-contrast), 2))
+  );
+  --color-gradient-bg-end: oklch(from var(--color-gradient-bg-start) l c h / 0);
+
   --color-gradient-promo-start: #ffd2f7;
   --color-gradient-promo-end: #b9dfff;
 }
@@ -114,21 +150,50 @@
 .theme-dark {
   color-scheme: dark;
 
-  --color-background: #1f1f20;
-  --color-surface: #9aa3af14;
-  --color-text-primary: #e5f0fc;
-  --color-text-secondary: #c2c7cd;
-  --color-text-tertiary: #94999f;
-  --color-accent: #0081ff;
-  --color-accent-b: #0081ff29;
+  /** Base color
+  By default it's blue ≈ #0289ff
+  Usually it's your brand color. Simply provide your value and the whole theme will be recalculated automatically.
+  Default value is in OKLCH because it produces richer P3 colors, however you can use any color format. 
+   */
+  /* --colors-accent: #00bc81; */
+  --color-accent: oklch(0.53 0.22 var(--theme-hue));
+
+  /* Relative colors 
+  These colors are calculated based on the accent color and saturation/contrast values.
+  Feel free to provide exact values if you want to override them.
+  */
+  --color-background-l: calc(0.35 - 0.35 * pow(var(--theme-contrast), 4));
+  --color-background: oklch(
+    from var(--color-accent) var(--color-background-l)
+      calc(var(--color-background-l) * 0.3 * var(--theme-saturation)) h
+  );
+  --color-background-blur: oklch(from var(--color-background) l c h / 0.9);
+
+  --color-text-primary-l: calc(0.7 + 0.3 * pow(var(--theme-contrast), 0.8));
+  --color-text-primary: oklch(
+    from var(--color-accent) var(--color-text-primary-l)
+      calc((1 - var(--color-text-primary-l)) * 0.6 * var(--theme-saturation)) h
+  );
+
+  --color-text-secondary: oklch(from var(--color-text-primary) l c h / 0.7);
+  --color-text-tertiary: oklch(from var(--color-text-primary) l c h / 0.5);
+  --color-accent-hover: oklch(from var(--color-accent) calc(l + 0.05) c h);
+  --color-accent-b: oklch(from var(--color-accent) l c h / 0.16);
+  --color-accent-b-hover: oklch(
+    from var(--color-accent-border) calc(l + 0.1) c h
+  );
+
+  --color-surface: oklch(from var(--color-text-primary) l c h / 0.04);
   --color-on-accent: white;
-  --color-button-primary-bg-hover: #0088f0d9;
-  --color-button-secondary-bg-hover: #0088f04d;
-  --color-border-level-2: #9aa3af29;
-  --color-border-level-3: #9aa3af52;
-  --color-background-blur: #1f1f20e6;
-  --color-gradient-bg-start: #0081ff1f;
-  --color-gradient-bg-end: #0081ff00;
+  --color-border-level-2: oklch(from var(--color-text-primary) l c h / 0.08);
+  --color-border-level-3: oklch(from var(--color-text-primary) l c h / 0.16);
+
+  --color-gradient-bg-start: oklch(
+    from var(--color-accent) l calc(0.3 * pow(var(--theme-saturation), 0.5)) h /
+      calc(0.5 - 0.5 * pow(var(--theme-contrast), 2))
+  );
+  --color-gradient-bg-end: oklch(from var(--color-gradient-bg-start) l c h / 0);
+
   --color-gradient-promo-start: #800069;
   --color-gradient-promo-end: #005196;
 }
@@ -216,7 +281,7 @@ a {
 }
 
 a:hover {
-  color: var(--color-button-primary-bg-hover);
+  color: var(--color-accent-hover);
 }
 
 ul,
@@ -368,7 +433,7 @@ section {
     color: var(--color-on-accent);
 
     &:hover {
-      background-color: var(--color-button-primary-bg-hover);
+      background-color: var(--color-accent-hover);
       color: var(--color-on-accent);
     }
   }
@@ -378,7 +443,7 @@ section {
     color: var(--color-accent);
 
     &:hover {
-      background-color: var(--color-button-secondary-bg-hover);
+      background-color: var(--color-accent-b-hover);
     }
   }
 
@@ -454,7 +519,7 @@ section {
   display: flex;
 
   &:hover {
-    color: var(--color-button-primary-bg-hover);
+    color: var(--color-accent-hover);
   }
 }
 


### PR DESCRIPTION
In this PR I'm converting all static colors into relative ones.

Light/dark theme still is set by a class on body. In each theme there are two input parameters:
```
--color-accent: oklch(0.64 0.21 255);
--theme-saturation: 0.2;
--theme-contrast: 0.8;
```
From these three input all other colors are calculated.

This allows users:
1. Plug in a brand color as --color-accent and everything is calculated automatically.
2. Adjust saturation of the theme with a single parameter
3. Adjust contrast of the theme with a single parameter